### PR TITLE
Performance optimizations (redux)

### DIFF
--- a/R/buildup_index.r
+++ b/R/buildup_index.r
@@ -25,8 +25,8 @@ buildup_index <- function(dmc, dc) {
   bui1 <- 0.8 * dc * dmc / (dmc + 0.4 * dc)
   bui1[dmc == 0 & dc == 0] <- 0
   # Eq. 27b - next 3 lines
-  p <- (dmc - bui1) / dmc
-  p[dmc == 0] <- 0
+  p <- rep(0, length(dmc))
+  p[dmc != 0] <- (dmc[dmc != 0] - bui1[dmc != 0]) / dmc[dmc != 0]
   cc <- 0.92 + ((0.0114 * dmc)^1.7)
   bui0 <- dmc - cc * p
   # Constraints

--- a/R/buildup_index.r
+++ b/R/buildup_index.r
@@ -22,14 +22,17 @@
 
 buildup_index <- function(dmc, dc) {
   # Eq. 27a
-  bui1 <- ifelse(dmc == 0 & dc == 0, 0, 0.8 * dc * dmc / (dmc + 0.4 * dc))
+  bui1 <- 0.8 * dc * dmc / (dmc + 0.4 * dc)
+  bui1[dmc == 0 & dc == 0] <- 0
   # Eq. 27b - next 3 lines
-  p <- ifelse(dmc == 0, 0, (dmc - bui1) / dmc)
+  p <- (dmc - bui1) / dmc
+  p[dmc == 0] <- 0
   cc <- 0.92 + ((0.0114 * dmc)^1.7)
   bui0 <- dmc - cc * p
   # Constraints
-  bui0 <- ifelse(bui0 < 0, 0, bui0)
-  bui1 <- ifelse(bui1 < dmc, bui0, bui1)
+  bui0[bui0 < 0] <- 0
+  bui1[bui1 < dmc] <- bui0[bui1 < dmc]
+  bui1[bui1 >= dmc] <- bui1[bui1 >= dmc]
   return(bui1)
 }
 

--- a/R/drought_code.r
+++ b/R/drought_code.r
@@ -36,17 +36,17 @@ drought_code <- function(
   fl02 <- c(6.4, 5, 2.4, 0.4, -1.6, -1.6, -1.6, -1.6, -1.6, 0.9, 3.8, 5.8)
   # Near the equator, we just use 1.4 for all months.
   # Constrain temperature
-  temp <- ifelse(temp < (-2.8), -2.8, temp)
+  temp[temp < (-2.8)] <- -2.8
 
   # Eq. 22 - Potential Evapotranspiration
   pe <- (0.36 * (temp + 2.8) + fl01[mon]) / 2
   # Daylength factor adjustment by latitude for Potential Evapotranspiration
   if (lat.adjust) {
-    pe <- ifelse(lat <= -20, (0.36 * (temp + 2.8) + fl02[mon]) / 2, pe)
-    pe <- ifelse(lat > -20 & lat <= 20, (0.36 * (temp + 2.8) + 1.4) / 2, pe)
+    pe[lat <= -20] <- (0.36 * (temp[lat <= -20] + 2.8) + fl02[mon]) / 2
+    pe[lat > -20 & lat <= 20] <- (0.36 * (temp[lat > -20 & lat <= 20] + 2.8) + 1.4) / 2
   }
   # Cap potential evapotranspiration at 0 for negative winter DC values
-  pe <- ifelse(pe < 0, 0, pe)
+  pe[pe < 0] <- 0
   ra <- prec
   # Eq. 18 - Effective Rainfall
   rw <- 0.83 * ra - 1.27
@@ -54,12 +54,13 @@ drought_code <- function(
   smi <- 800 * exp(-1 * dc_yda / 400)
   # Alteration to Eq. 21
   dr0 <- dc_yda - 400 * log(1 + 3.937 * rw / smi)
-  dr0 <- ifelse(dr0 < 0, 0, dr0)
+  dr0[dr0 < 0] <- 0
   # if precip is less than 2.8 then use yesterday's DC
-  dr <- ifelse(prec <= 2.8, dc_yda, dr0)
+  dr <- dr0
+  dr[prec <= 2.8] <- dc_yda[prec <= 2.8]
   # Alteration to Eq. 23
   dc1 <- dr + pe
-  dc1 <- ifelse(dc1 < 0, 0, dc1)
+  dc1[dc1 < 0] <- 0
   return(dc1)
 }
 

--- a/R/fine_fuel_moisture_code.r
+++ b/R/fine_fuel_moisture_code.r
@@ -29,21 +29,17 @@ fine_fuel_moisture_code <- function(ffmc_yda, temp, rh, ws, prec) {
   wmo <- 147.27723 * (101 - ffmc_yda) / (59.5 + ffmc_yda)
   # Eq. 2 Rain reduction to allow for loss in
   #  overhead canopy
-  ra <- ifelse(prec > 0.5, prec - 0.5, prec)
+  ra <- prec
+  ra[prec > 0.5] <- prec[prec > 0.5] - 0.5
   # Eqs. 3a & 3b
-  wmo <- ifelse(
-    prec > 0.5,
-    ifelse(
-      wmo > 150,
-      (wmo + 0.0015 * (wmo - 150) * (wmo - 150) * sqrt(ra)
-        + 42.5 * ra * exp(-100 / (251 - wmo)) * (1 - exp(-6.93 / ra))),
-      wmo + 42.5 * ra * exp(-100 / (251 - wmo)) * (1 - exp(-6.93 / ra))
-    ),
-    wmo
-  )
+  wmo.sel <- prec > 0.5 & wmo > 150 
+  wmo[wmo.sel] <- (wmo[wmo.sel] + 0.0015 * (wmo[wmo.sel] - 150) * (wmo[wmo.sel] - 150) * sqrt(ra[wmo.sel]) + 
+                     42.5 * ra[wmo.sel] * exp(-100 / (251 - wmo[wmo.sel])) * (1 - exp(-6.93 / ra[wmo.sel])))
+  wmo.sel <- prec > 0.5 & wmo <= 150
+  wmo[wmo.sel] <- wmo[wmo.sel] + 42.5 * ra[wmo.sel] * exp(-100 / (251 - wmo[wmo.sel])) * (1 - exp(-6.93 / ra[wmo.sel]))
   # The real moisture content of pine litter ranges up to about 250 percent,
   # so we cap it at 250
-  wmo <- ifelse(wmo > 250, 250, wmo)
+  wmo[wmo > 250] <- 250
   # Eq. 4 Equilibrium moisture content from drying
   ed <- (0.942 * (rh^0.679) + (11 * exp((rh - 100) / 10))
     + 0.18 * (21.1 - temp) * (1 - 1 / exp(rh * 0.115)))
@@ -51,32 +47,29 @@ fine_fuel_moisture_code <- function(ffmc_yda, temp, rh, ws, prec) {
   ew <- (0.618 * (rh^0.753) + (10 * exp((rh - 100) / 10))
     + 0.18 * (21.1 - temp) * (1 - 1 / exp(rh * 0.115)))
   # Eq. 6a (ko) Log drying rate at the normal temperature of 21.1 C
-  z <- ifelse(
-    wmo < ed & wmo < ew,
-    (0.424 * (1 - (((100 - rh) / 100)^1.7))
-      + 0.0694 * sqrt(ws) * (1 - ((100 - rh) / 100)^8)),
-    0
-  )
+  z <- rep(0.0, length(wmo))
+  z.sel <- wmo < ed & wmo < ew
+  z[z.sel] <- (0.424 * (1 - (((100 - rh[z.sel]) / 100)^1.7))
+               + 0.0694 * sqrt(ws[z.sel]) * (1 - ((100 - rh[z.sel]) / 100)^8))
   # Eq. 6b Affect of temperature on  drying rate
   x <- z * 0.581 * exp(0.0365 * temp)
   # Eq. 8
-  wm <- ifelse(wmo < ed & wmo < ew, ew - (ew - wmo) / (10^x), wmo)
+  wm <- wmo
+  wm.sel <- wmo < ed & wmo < ew
+  wm[wm.sel] <- ew[wm.sel] - (ew[wm.sel] - wmo[wm.sel]) / (10^x[wm.sel])
   # Eq. 7a (ko) Log wetting rate at the normal temperature of 21.1 C
-  z <- ifelse(
-    wmo > ed,
-    (0.424 * (1 - (rh / 100)^1.7)
-      + 0.0694 * sqrt(ws) * (1 - (rh / 100)^8)),
-    z
-  )
+  z.sel <- wmo > ed
+  z[z.sel] <- (0.424 * (1 - (rh[z.sel] / 100)^1.7) + 0.0694 * sqrt(ws[z.sel]) * (1 - (rh[z.sel] / 100)^8))
   # Eq. 7b Affect of temperature on  wetting rate
   x <- z * 0.581 * exp(0.0365 * temp)
   # Eq. 9
-  wm <- ifelse(wmo > ed, ed + (wmo - ed) / (10^x), wm)
+  wm[wmo > ed] <- ed[wmo > ed] + (wmo[wmo > ed] - ed[wmo > ed]) / (10^x[wmo > ed])
+  wm[is.na(wmo > ed)] <- NA
   # Eq. 10 Final ffmc calculation
   ffmc1 <- (59.5 * (250 - wm)) / (147.27723 + wm)
   # Constraints
-  ffmc1 <- ifelse(ffmc1 > 101, 101, ffmc1)
-  ffmc1 <- ifelse(ffmc1 < 0, 0, ffmc1)
+  ffmc1[ffmc1 > 101] <- 101
+  ffmc1[ffmc1 < 0] <- 0
   return(ffmc1)
 }
 

--- a/R/fwi.r
+++ b/R/fwi.r
@@ -403,13 +403,13 @@ fwi <- function(
   # Length of weather run
   n0 <- length(temp) / n
   # Initialize variables
-  ffmc <- dmc <- dc <- isi <- bui <- fwi <- dsr <- NULL
+  ffmc <- dmc <- dc <- isi <- bui <- fwi <- dsr <- rep(NA_real_, length(temp))
   # For each day in the run
   for (i in 1:n0) {
     # k is the data for all stations by day
     k <- ((i - 1) * n + 1):(i * n)
     # constrain relative humidity
-    rh[k] <- ifelse(rh[k] >= 100, 99.9999, rh[k])
+    if(any(rh[k] >= 100))rh[k][rh[k] >= 100] <- 99.9999
     ###########################################################################
     # Fine Fuel Moisture Code (FFMC)
     ###########################################################################
@@ -452,13 +452,13 @@ fwi <- function(
     dsr1 <- 0.0272 * (fwi1^1.77)
 
     # Concatenate values
-    ffmc <- c(ffmc, ffmc1)
-    dmc <- c(dmc, dmc1)
-    dc <- c(dc, dc1)
-    isi <- c(isi, isi1)
-    bui <- c(bui, bui1)
-    fwi <- c(fwi, fwi1)
-    dsr <- c(dsr, dsr1)
+    ffmc[k] <- ffmc1
+    dmc[k] <- dmc1
+    dc[k] <- dc1
+    isi[k] <- isi1
+    bui[k] <- bui1
+    fwi[k] <- fwi1
+    dsr[k] <- dsr1
     ffmc_yda <- ffmc1
     dmc_yda <- dmc1
     dc_yda <- dc1

--- a/R/initial_spread_index.r
+++ b/R/initial_spread_index.r
@@ -31,11 +31,15 @@ initial_spread_index <- function(
   # Eq. 24 - Wind Effect
   # the ifelse, also takes care of the ISI modification for the fbp functions
   # This modification is Equation 53a in FCFDG (1992)
-  fW <- ifelse(
-    ws >= 40 & fbpMod == TRUE,
-    12 * (1 - exp(-0.0818 * (ws - 28))),
-    exp(0.05039 * ws)
-  )
+  if(fbpMod){
+    fW <- rep(NA_real_, length(ws))
+    fW.sel <- ws >= 40
+    fW[fW.sel] <- 12 * (1 - exp(-0.0818 * (ws[fW.sel] - 28)))
+    fW[!fW.sel] <- exp(0.05039 * ws[!fW.sel])
+    fW[is.na(fW.sel)] <- NA
+  }else{
+    fW <- exp(0.05039 * ws)
+  }
   # Eq. 25 - Fine Fuel Moisture
   fF <- 91.9 * exp(-0.1386 * fm) * (1 + (fm^5.31) / 49300000)
   # Eq. 26 - Spread Index Equation

--- a/R/initial_spread_index.r
+++ b/R/initial_spread_index.r
@@ -33,7 +33,7 @@ initial_spread_index <- function(
   # This modification is Equation 53a in FCFDG (1992)
   if(fbpMod){
     fW <- rep(NA_real_, length(ws))
-    fW.sel <- ws >= 40
+    fW.sel <- ws >= 40 & !is.na(ws)
     fW[fW.sel] <- 12 * (1 - exp(-0.0818 * (ws[fW.sel] - 28)))
     fW[!fW.sel] <- exp(0.05039 * ws[!fW.sel])
     fW[is.na(fW.sel)] <- NA

--- a/tests/testthat/test_fwi.r
+++ b/tests/testthat/test_fwi.r
@@ -76,11 +76,8 @@ test_that("fwi_10", {
 test_that("fwi_11", {
   fct_test_fwi("fwi_11",
            function(test_fwi) {
-             expect_warning({
-               expect_warning(
+             expect_warning(
                  {actual <- fwi(test_fwi, batch = FALSE)},
-                 "*NaNs produced*")
-               },
                "Same initial data were used for multiple weather stations")
            return(actual)
            })


### PR DESCRIPTION
**This is a fixed version of PR #41**

This set of commits replaces ifelse statements in a number of functions with explicit attributions through logical indexing. Additionally, the output data frame in the fwi function is pre-allocated now to avoid incremental c statements that concatenate the results in the loop.

This decreases the computation time from 90 seconds to 30 seconds for my test data set, which is a data frame with ~15,000 records.

The tests ran successfully (with one minor modification of test fwi_11)